### PR TITLE
combine table changes into single query

### DIFF
--- a/install.php
+++ b/install.php
@@ -67,49 +67,25 @@ if(DB::IsError($check)) {
 	out(_("OK"));
 }
 
+$alterclauses = array();
+
 outn(_("checking for extra field.."));
 if (!$dbcdr->getAll('SHOW COLUMNS FROM `' . $db_cel_name . '`.`' . $db_cel_table_name . '` WHERE FIELD = "extra"')) {
-	// rename field
-	set_time_limit(0);
-	$sql = "ALTER TABLE `" . $db_cel_name . "`.`" . $db_cel_table_name . "` CHANGE `eventextra` `extra` varchar(512)";
-	$result = $dbcdr->query($sql);
-	if(DB::IsError($result)) {
-		out(_("ERROR failed to update extra field"));
-	} else {
-		out(_("OK"));
-	}
+	$alterclauses[] = "CHANGE `eventextra` `extra` varchar(512)";
+	out(_("not found"));
 } else {
 	out(_("already exists"));
 }
-//FREEPBX-12986
-/*
-outn(_("expanding appdata field.."));
-$sql = "ALTER TABLE `" . $db_cel_name . "`.`" . $db_cel_table_name . "` MODIFY `appdata` varchar(255)";
-$result = $dbcdr->query($sql);
-if(DB::IsError($result)) {
-	out(_("ERROR failed to update extra field"));
-} else {
-	out(_("OK"));
-}
- */
 
 // delete some extranous fields from earlier (incorrect) schemas
 $delfields = array("userfield", "src", "dst", "channel", "dstchannel");
 foreach ($delfields as $field) {
 	outn(sprintf(_("Checking for %s field to remove.."), $field));
 	if ($dbcdr->getAll('SHOW COLUMNS FROM `' . $db_cel_name . '`.`' . $db_cel_table_name . '` WHERE FIELD = "' . $field . '"')) {
-		// drop column
-		set_time_limit(0);
-		outn(_("removing (this might take a long time)"));
-		$sql = "ALTER TABLE `" . $db_cel_name . "`.`" . $db_cel_table_name . "` DROP COLUMN `" . $field . "`";
-		$result = $dbcdr->query($sql);
-		if(DB::IsError($result)) {
-			out(sprintf(_("ERROR failed to delete %s field"), $field));
-		} else {
-			out(_("Removed"));
-		}
+		$alterclauses[] = "DROP COLUMN `$field`";
+		out(_("found"));
 	} else {
-		out(_("Already Removed"));
+		out(_("already removed"));
 	}
 }
 
@@ -117,19 +93,25 @@ outn(_("Checking for context index.."));
 $sql = "SHOW INDEXES FROM `" . $db_cel_name . "`.`" . $db_cel_table_name . "` WHERE Key_name='context_index'";
 $check = $dbcdr->getOne($sql);
 if (empty($check)) {
-	outn(_("Adding (this might take a long time)"));
-	$sql = "ALTER TABLE `" . $db_cel_name . "`.`" . $db_cel_table_name . "` ADD INDEX context_index (context)";
-	$result = $dbcdr->query($sql);
-	if(DB::IsError($result)) {
-		out(_("ERROR failed to add context index"));
-	} else {
-		out(_("OK"));
-	}
+	$alterclauses[] = "ADD INDEX context_index (context)";
+	out(_("found"));
 } else {
-	out(_("Already indexed"));
+	out(_("already indexed"));
 }
 
-
+if (count($alterclauses)) {
+	// drop column
+	set_time_limit(0);
+	outn(_("Removing outdated fields (this might take a long time)"));
+	$sql = "ALTER TABLE `" . $db_cel_name . "`.`" . $db_cel_table_name . "`";
+	$sql .= implode(",", $alterclauses);
+	$result = $dbcdr->query($sql);
+	if(DB::IsError($result)) {
+		out(_("ERROR failed to update database"));
+	} else {
+		out(_("Removed"));
+	}
+}
 
 $set['value'] = true;
 $set['defaultval'] = true;


### PR DESCRIPTION
[FREEPBX-13517](http://issues.freepbx.org/browse/FREEPBX-13517) got closed because you "are already on track to do this." What wasn't made clear is if a rewrite of the installer is coming to version 13, or just to 14. Even if version 14 handles this more efficiently, the statements in question will only get run when upgrading to 13, so here's a quick fix that makes these table changes into one statement instead of 7.

Due to the way the upgrade process from 12 to 13 runs, I wasn't able to test the PHP part of the code, but it's just simple array building and imploding. I can confirm that the SQL works just fine, and is much faster: 

    ALTER TABLE `asteriskcdrdb`.`cel` CHANGE `eventextra` `extra` varchar(512), DROP COLUMN `userfield`, DROP COLUMN `src`, DROP COLUMN `dst`, DROP COLUMN `channel`, DROP COLUMN `dstchannel`, ADD INDEX context_index (context);