### PR TITLE
After Backup/Restore Special Characters aren't displayed correctly

### DIFF
--- a/Backup.php
+++ b/Backup.php
@@ -11,7 +11,7 @@ class Backup Extends Base\BackupBase{
 			$dumpOtherOptions[] = "--where='" . $query . "'";
 		}
 		
-		$dumpOtherOptions[] = '--opt --compact --skip-lock-tables --skip-triggers --no-create-info';
+		$dumpOtherOptions[] = '--opt --skip-lock-tables --skip-triggers --no-create-info --default-character-set=utf8mb4';
 		$dumpOtherOptions = implode(" ", $dumpOtherOptions);
 		$fileObj = $this->dumpTableIntoFile('cel', 'cel', $dumpOtherOptions, true);
 		$this->addDirectories([$fileObj->getPath()]);


### PR DESCRIPTION
the mysqldump option '--compact' sets the option '--skip-set-charset' so no charset info is written to the sql-dump. This PR removes the --compact option and sets the default charset to utf8

Bugfix FreePBX/issue-tracker#691